### PR TITLE
Check if the inputs are same id, disable the letsgo button

### DIFF
--- a/cheapTrip/src/app/trip-direction/select-direction/select-direction.component.html
+++ b/cheapTrip/src/app/trip-direction/select-direction/select-direction.component.html
@@ -79,7 +79,7 @@
     <div class="actions">
       <button mat-flat-button color="accent" type="reset" (click)="cleanForm()" i18n = "Clear form@@clearform">Clear form</button>
       <button mat-flat-button color="primary" style="color: white;"
-       #sBtn [disabled]="endPoint.name.length < 1 || startPoint.name.length < 1"
+       #sBtn [disabled]="(endPoint.name.length < 1 || startPoint.name.length < 1) || (startPoint.id == endPoint.id)"
         type="submit" i18n = "letsgo@@letsgo">Let's go</button>
     </div>
 


### PR DESCRIPTION
The added simple a line of code checks the the "from" and "to" inputs, if values' ids are same then disables let's go button.
Indirectly resolves #50 and resolves #51 . 

Also, instead making the let's go button disable, we can follow another approach like showing an error message via popup by checking the value ids in onSubmit function like bellow.

Which is better not sure?

```
onSubmit(): void {
    console.log ("SUBMITTED!");

    if(this.startPoint.name == this.endPoint.name) {
      // Note that i18n messages related lines is not added
      this.errorInterceptor.showError ($localize`:@@oops:Oops`,$localize`:@@onlyRusEng:opps same input!!!`);
    }else {
      this.store.dispatch(new TripDirectionActions.GetRouts());
    }

  }
```
